### PR TITLE
Fix id card/licenses not displayed

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -14,19 +14,20 @@ Config.Cityhalls = {
             title = "City Services"
         },
         licenses = {
-            ["id_card"] = {
-                label = "ID Card",
+            ["id"] = {
+                item = 'id_card',
+                label = "ID",
                 cost = 50,
             },
-            ["driver_license"] = {
+            ["driver"] = {
+                item = 'driver_license',
                 label = "Driver License",
                 cost = 50,
-                metadata = "driver"
             },
-            ["weaponlicense"] = {
+            ["weapon"] = {
+                item = 'weaponlicense',
                 label = "Weapon License",
                 cost = 50,
-                metadata = "weapon"
             },
         }
     },

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,19 +78,19 @@ RegisterNetEvent('qb-cityhall:server:requestId', function(item, hall)
         return TriggerClientEvent('QBCore:Notify', src, ('You don\'t have enough money on you, you need $%s cash'):format(itemInfo.cost), 'error')
     end
     local metadata = {}
-    if item == "id_card" then
+    if item.item == "id_card" then
         metadata = {
             type = string.format('%s %s', Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname),
             description = string.format('CID: %s  \nBirth date: %s  \nSex: %s  \nNationality: %s',
             Player.PlayerData.citizenid, Player.PlayerData.charinfo.birthdate, Player.PlayerData.charinfo.gender == 0 and 'Male' or 'Female', Player.PlayerData.charinfo.nationality)
         }
-    elseif item == "driver_license" then
+    elseif item.item == "driver_license" then
         metadata = {
             type = 'Class C Driver License',
             description = string.format('First name: %s  \nLast name: %s  \nBirth date: %s',
             Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname, Player.PlayerData.charinfo.birthdate)
         }
-    elseif item == "weaponlicense" then
+    elseif item.item == "weaponlicense" then
         metadata = {
             type = string.format('%s %s', Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname),
             description = string.format('First name: %s  \nLast name: %s  \nBirth date: %s',

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,19 +78,19 @@ RegisterNetEvent('qb-cityhall:server:requestId', function(item, hall)
         return TriggerClientEvent('QBCore:Notify', src, ('You don\'t have enough money on you, you need $%s cash'):format(itemInfo.cost), 'error')
     end
     local metadata = {}
-    if item.item == "id_card" then
+    if itemInfo.item == "id_card" then
         metadata = {
             type = string.format('%s %s', Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname),
             description = string.format('CID: %s  \nBirth date: %s  \nSex: %s  \nNationality: %s',
             Player.PlayerData.citizenid, Player.PlayerData.charinfo.birthdate, Player.PlayerData.charinfo.gender == 0 and 'Male' or 'Female', Player.PlayerData.charinfo.nationality)
         }
-    elseif item.item == "driver_license" then
+    elseif itemInfo.item == "driver_license" then
         metadata = {
             type = 'Class C Driver License',
             description = string.format('First name: %s  \nLast name: %s  \nBirth date: %s',
             Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname, Player.PlayerData.charinfo.birthdate)
         }
-    elseif item.item == "weaponlicense" then
+    elseif itemInfo.item == "weaponlicense" then
         metadata = {
             type = string.format('%s %s', Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname),
             description = string.format('First name: %s  \nLast name: %s  \nBirth date: %s',

--- a/server/main.lua
+++ b/server/main.lua
@@ -99,9 +99,8 @@ RegisterNetEvent('qb-cityhall:server:requestId', function(item, hall)
     else
         return DropPlayer(src, 'Attempted exploit abuse')
     end
-    if not Player.Functions.AddItem(item, 1, nil, metadata) then return end
-    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[item], 'add')
-    TriggerClientEvent('QBCore:Notify', src, ('You have received your %s for $%s'):format(QBCore.Shared.Items[item].label, itemInfo.cost), 'success')
+    if not Player.Functions.AddItem(itemInfo.item, 1, nil, metadata) then return end
+    TriggerClientEvent('QBCore:Notify', src, ('You have received your %s for $%s'):format(QBCore.Shared.Items[itemInfo.item].label, itemInfo.cost), 'success')
 end)
 
 RegisterNetEvent('qb-cityhall:server:sendDriverTest', function()


### PR DESCRIPTION
## Description

Since qbx-cityhall code has changed and we're now verifying the metadata and item with the same value, it will not display. Added an item line on config and provided the name to requestId netevent.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
