### PR TITLE
refactor: blips and event names

### DIFF
--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,14 +1,14 @@
 return {
     cityhalls = {
-        { -- Cityhall 1
+        {
             coords = vec3(-265.0, -963.6, 31.2),
             showBlip = true,
-            blipData = {
+            blip = {
+                label = 'City Services',
                 sprite = 487,
                 display = 4,
                 scale = 0.65,
                 colour = 0,
-                title = 'City Services',
             },
             licenses = {
                 ['id'] = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -14,7 +14,7 @@ local function getClosestHall(pedCoords)
     return closest
 end
 
-RegisterNetEvent('qb-cityhall:server:requestId', function(item, hall)
+RegisterNetEvent('qbx_cityhall:server:requestId', function(item, hall)
     local src = source
     local Player = exports.qbx_core:GetPlayer(src)
     if not Player then return end
@@ -34,7 +34,7 @@ RegisterNetEvent('qb-cityhall:server:requestId', function(item, hall)
     exports.qbx_core:Notify(src, Lang:t('info.item_received', {label = itemInfo.label, cost = itemInfo.cost}), 'success')
 end)
 
-RegisterNetEvent('qb-cityhall:server:ApplyJob', function(job)
+RegisterNetEvent('qbx_cityhall:server:ApplyJob', function(job)
     local src = source
     local Player = exports.qbx_core:GetPlayer(src)
     if not Player then return end


### PR DESCRIPTION
## Description

- Refactor blips
- Switch event names to `qbx_` from `qb-`
- Use `cache.resource` instead of `GetCurrentResourceName()`
- Add the `onResourceStart` event handler for testing and restarting purposes

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
